### PR TITLE
Changes to allow installation via pip

### DIFF
--- a/nextbus/api.py
+++ b/nextbus/api.py
@@ -27,7 +27,7 @@ def route_config(agency=None, route=None, **kwargs):
 
 def predictions(agency=None, route=None, stop_id=None, **kwargs):
     """prediction"""
-    result = __api_call('predictions', agency=agency, route=route, stop_id=stop_id, **kwargs) or []
+    result = __api_call('predictions', agency=agency, route=route, stopId=stop_id, **kwargs) or []
     return result
 
 def set_defaults(defaults):

--- a/nextbus/model.py
+++ b/nextbus/model.py
@@ -1,5 +1,10 @@
 from lxml import etree
 
+
+class UnknownCommandError(Exception):
+    pass
+
+
 def parse_command(command, xml):
     """parses the xml document based on the command used. returns the object structure
     associated with that xml"""
@@ -10,6 +15,8 @@ def parse_command(command, xml):
         result = __parse_routeList(xml)
     elif command == 'routeConfig':
         result = __parse_routeConfig(xml)
+    else:
+        raise UnknownCommandError("Command {0} is not recognized or not implemented".format(command))
 
     return result
 

--- a/nextbus/test_nextbus.py
+++ b/nextbus/test_nextbus.py
@@ -4,19 +4,32 @@ from nextbus.model import Agency, Route
 
 import unittest
 
-def test_agencyList():
-    #agency list should always return a list of agencies
-    agencies = nextbus.agency_list()
-    assert len(agencies) > 0 and type(agencies[0]) == Agency
+class AgencyListTest(unittest.TestCase):
+    def test_agencyList(self):
+        #agency list should always return a list of agencies
+        agencies = nextbus.agency_list()
+        self.assertTrue(len(agencies) > 0, "Agencies list should not be empty")
+        self.assertTrue(isinstance(agencies[0], Agency), "agency_list not returning a list of Agencies")
+            # if willing to break 2.6, can use assertIsInstance instead
 
-def test_routeList():
-    #route list should always return a list of routes filtered by agency.
-    routes = nextbus.route_list(agency='sf-muni')
-    assert len(routes) > 0 and type(routes[0]) == Route and routes[0].title == 'F-Market & Wharves'
+    def test_routeList(self):
+        #route list should always return a list of routes filtered by agency.
+        routes = nextbus.route_list(agency='sf-muni')
+        self.assertTrue(len(routes) > 0,
+                        "Routes list should not be empty")
+        self.assertTrue(isinstance(routes[0], Route),
+                        "route_list not returning a list of Routes")
+        self.assertTrue("F-Market & Wharves" in [route.title for route in routes],
+                        "A route is missing from the route list")
+        self.assertFalse("Sandwich" in [route.title for route in routes],
+                         "route_list is including multiple agencies")
 
-def test_routeConfig():
-    #route config should return a route object by the given route tag
-    route = nextbus.route_config(agency='sf-muni', route='1')
-    assert route and type(route) == Route and route.title == '1-California'
+    def test_routeConfig(self):
+        #route config should return a route object by the given route tag
+        route = nextbus.route_config(agency='sf-muni', route='1')
+        self.assertTrue(route, "Route is empty")
+        self.assertTrue(isinstance(route, Route), "route_config is not returning a Route")
+        self.assertEqual(route.title, "1-California",
+                         "Route title is not right (expected '{0}', got '{1}'".format("1-California", route.title))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.0.1
-lxml==3.2.4
+requests>=2.0.1
+lxml>=3.2.4

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@
 import os
 import sys
 
-import nextbus
-
 try:
     from setuptools import setup
 except ImportError:
@@ -18,19 +16,19 @@ packages = [
     'nextbus',
 ]
 
-requires = []
+requires = ['requests>=2.0.1', 'lxml>=3.2.4']
 
 readme =''
 history =''
 
 setup(
     name='python-nextbus',
-    version=nextbus.__version__,
+    version='0.1b',
     description='python client for nextbus api',
     long_description=readme + '\n\n' + history,
     author='Sam Bolgert',
     author_email='sbolgert@gmail.com',
-    url='http://python.org',
+    url='https://github.com/linuxlewis/python-nextbus',
     packages=packages,
     package_data={'': ['LICENSE', 'NOTICE']},
     package_dir={'nextbus': 'nextbus'},
@@ -39,7 +37,7 @@ setup(
     license=license,
     zip_safe=False,
     classifiers=(
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 6 - Mature',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
@@ -47,6 +45,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
-
+        'Programming Language :: Python :: 3.5'
     ),
 )


### PR DESCRIPTION
So it turns out that because of a few changes to pip, nobody can actually install `python-nextbus` on pip, and even if you try to clone the repo, you can't `pip install` it locally. This is a first attempt at trying to fix this.

At least I can get this to work on python 3.5; the other nextbus parser on PyPI doesn't even work on newer versions of Python.